### PR TITLE
Correcting instances of greeting services in test, according to the DIs

### DIFF
--- a/src/main/java/guru/springframework/sfgdi/SfgDiApplication.java
+++ b/src/main/java/guru/springframework/sfgdi/SfgDiApplication.java
@@ -1,9 +1,6 @@
 package guru.springframework.sfgdi;
 
-import guru.springframework.sfgdi.controllers.ConstructorInjectedController;
-import guru.springframework.sfgdi.controllers.MyController;
-import guru.springframework.sfgdi.controllers.PropertyInjectedController;
-import guru.springframework.sfgdi.controllers.SetterInjectedController;
+import guru.springframework.sfgdi.controllers.*;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
@@ -13,6 +10,9 @@ public class SfgDiApplication {
 
 	public static void main(String[] args) {
 		ApplicationContext ctx = SpringApplication.run(SfgDiApplication.class, args);
+
+		I18nController i18nController = (I18nController) ctx.getBean("i18nController");
+		System.out.println(i18nController.sayHello());
 
 		MyController myController = (MyController) ctx.getBean("myController");
 

--- a/src/main/java/guru/springframework/sfgdi/controllers/ConstructorInjectedController.java
+++ b/src/main/java/guru/springframework/sfgdi/controllers/ConstructorInjectedController.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Controller;
 public class ConstructorInjectedController {
     private final GreetingService greetingService;
 
-    public ConstructorInjectedController(@Qualifier("constructorGreetingService") GreetingService greetingService) {
+    public ConstructorInjectedController(@Qualifier("constructorInjectedGreetingService") GreetingService greetingService) {
         this.greetingService = greetingService;
     }
 

--- a/src/main/java/guru/springframework/sfgdi/controllers/I18nController.java
+++ b/src/main/java/guru/springframework/sfgdi/controllers/I18nController.java
@@ -1,0 +1,21 @@
+package guru.springframework.sfgdi.controllers;
+
+import guru.springframework.sfgdi.services.GreetingService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class I18nController {
+    private final GreetingService greetingService;
+
+    public I18nController(@Qualifier("i18nService") GreetingService greetingService) {
+        // there are two services named "i18nService"
+        // we added the @Profile annotaion to make the output dependent of the users active profile
+        // without the profile, Spring wouldn't know which one to get --> throws error
+        this.greetingService = greetingService;
+    }
+
+    public String sayHello(){
+        return greetingService.sayGreeting();
+    }
+}

--- a/src/main/java/guru/springframework/sfgdi/services/ConstructorInjectedGreetingService.java
+++ b/src/main/java/guru/springframework/sfgdi/services/ConstructorInjectedGreetingService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
  * Created by jt on 12/26/19.
  */
 @Service
-public class ConstructorGreetingService implements GreetingService {
+public class ConstructorInjectedGreetingService implements GreetingService {
     @Override
     public String sayGreeting() {
         return "Hello World - Constructor";

--- a/src/main/java/guru/springframework/sfgdi/services/I18nEnglishGreetingService.java
+++ b/src/main/java/guru/springframework/sfgdi/services/I18nEnglishGreetingService.java
@@ -1,0 +1,16 @@
+package guru.springframework.sfgdi.services;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Profile("EN")
+// there are two services named "i18nService"
+// we added the @Profile annotaion to make the output dependent of the users active profile
+// without the profile, Spring wouldn't know which one to get --> throws error
+@Service("i18nService")
+public class I18nEnglishGreetingService implements GreetingService{
+    @Override
+    public String sayGreeting(){
+        return "Hello World – EN";
+    }
+}

--- a/src/main/java/guru/springframework/sfgdi/services/I18nSpanishGreetingService.java
+++ b/src/main/java/guru/springframework/sfgdi/services/I18nSpanishGreetingService.java
@@ -1,0 +1,16 @@
+package guru.springframework.sfgdi.services;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Profile("ES")
+// there are two services named "i18nService"
+// we added the @Profile annotaion to make the output dependent of the users active profile
+// without the profile, Spring wouldn't know which one to get --> throws error
+@Service("i18nService")
+public class I18nSpanishGreetingService implements GreetingService {
+    @Override
+    public String sayGreeting(){
+        return "Hola Mundo – ES";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.profiles.active=ES

--- a/src/test/java/guru/springframework/sfgdi/controllers/ConstructorInjectedControllerTest.java
+++ b/src/test/java/guru/springframework/sfgdi/controllers/ConstructorInjectedControllerTest.java
@@ -1,6 +1,6 @@
 package guru.springframework.sfgdi.controllers;
 
-import guru.springframework.sfgdi.services.ConstructorGreetingService;
+import guru.springframework.sfgdi.services.ConstructorInjectedGreetingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +10,7 @@ class ConstructorInjectedControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new ConstructorInjectedController(new ConstructorGreetingService());
+        controller = new ConstructorInjectedController(new ConstructorInjectedGreetingService());
     }
 
     @Test

--- a/src/test/java/guru/springframework/sfgdi/controllers/PropertyInjectedControllerTest.java
+++ b/src/test/java/guru/springframework/sfgdi/controllers/PropertyInjectedControllerTest.java
@@ -1,6 +1,6 @@
 package guru.springframework.sfgdi.controllers;
 
-import guru.springframework.sfgdi.services.ConstructorGreetingService;
+import guru.springframework.sfgdi.services.PropertyInjectedGreetingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,7 @@ class PropertyInjectedControllerTest {
     void setUp() {
         controller = new PropertyInjectedController();
 
-        controller.greetingService = new ConstructorGreetingService();
+        controller.greetingService = new PropertyInjectedGreetingService();
     }
 
     @Test

--- a/src/test/java/guru/springframework/sfgdi/controllers/SetterInjectedControllerTest.java
+++ b/src/test/java/guru/springframework/sfgdi/controllers/SetterInjectedControllerTest.java
@@ -1,6 +1,6 @@
 package guru.springframework.sfgdi.controllers;
 
-import guru.springframework.sfgdi.services.ConstructorGreetingService;
+import guru.springframework.sfgdi.services.SetterInjectedGreetingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +11,7 @@ class SetterInjectedControllerTest {
     @BeforeEach
     void setUp() {
         controller = new SetterInjectedController();
-        controller.setGreetingService(new ConstructorGreetingService());
+        controller.setGreetingService(new SetterInjectedGreetingService());
     }
 
     @Test


### PR DESCRIPTION
ConstructorGreetingService was used in all Controller Tests, regardless of the DI.
Changed ConstructorGreetingService to Constructor**Injected**GreetingService, due to naming consistency.

These changes also affect the Branch _using-qualifiers_