### PR TITLE
Correcting instances of greeting services in test, according to the DIs

### DIFF
--- a/src/main/java/guru/springframework/sfgdi/controllers/ConstructorInjectedController.java
+++ b/src/main/java/guru/springframework/sfgdi/controllers/ConstructorInjectedController.java
@@ -4,9 +4,6 @@ import guru.springframework.sfgdi.services.GreetingService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
 
-/**
- * Created by jt on 12/26/19.
- */
 @Controller
 public class ConstructorInjectedController {
     private final GreetingService greetingService;

--- a/src/main/java/guru/springframework/sfgdi/controllers/ConstructorInjectedController.java
+++ b/src/main/java/guru/springframework/sfgdi/controllers/ConstructorInjectedController.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Controller;
 public class ConstructorInjectedController {
     private final GreetingService greetingService;
 
-    public ConstructorInjectedController(@Qualifier("constructorGreetingService") GreetingService greetingService) {
+    public ConstructorInjectedController(@Qualifier("constructorInjectedGreetingService") GreetingService greetingService) {
         this.greetingService = greetingService;
     }
 

--- a/src/main/java/guru/springframework/sfgdi/services/ConstructorInjectedGreetingService.java
+++ b/src/main/java/guru/springframework/sfgdi/services/ConstructorInjectedGreetingService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
  * Created by jt on 12/26/19.
  */
 @Service
-public class ConstructorGreetingService implements GreetingService {
+public class ConstructorInjectedGreetingService implements GreetingService {
     @Override
     public String sayGreeting() {
         return "Hello World - Constructor";

--- a/src/main/java/guru/springframework/sfgdi/services/I18NSpanishService.java
+++ b/src/main/java/guru/springframework/sfgdi/services/I18NSpanishService.java
@@ -3,10 +3,7 @@ package guru.springframework.sfgdi.services;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
-/**
- * Created by jt on 12/27/19.
- */
-@Profile("ES")
+@Profile({"ES", "default"})
 @Service("i18nService")
 public class I18NSpanishService implements GreetingService {
     @Override

--- a/src/main/java/guru/springframework/sfgdi/services/I18nEnglishGreetingService.java
+++ b/src/main/java/guru/springframework/sfgdi/services/I18nEnglishGreetingService.java
@@ -3,9 +3,6 @@ package guru.springframework.sfgdi.services;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
-/**
- * Created by jt on 12/27/19.
- */
 @Profile("EN")
 @Service("i18nService")
 public class I18nEnglishGreetingService implements GreetingService {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.profiles.active=ES
+#spring.profiles.active=EN

--- a/src/test/java/guru/springframework/sfgdi/controllers/ConstructorInjectedControllerTest.java
+++ b/src/test/java/guru/springframework/sfgdi/controllers/ConstructorInjectedControllerTest.java
@@ -1,6 +1,6 @@
 package guru.springframework.sfgdi.controllers;
 
-import guru.springframework.sfgdi.services.ConstructorGreetingService;
+import guru.springframework.sfgdi.services.ConstructorInjectedGreetingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +10,7 @@ class ConstructorInjectedControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new ConstructorInjectedController(new ConstructorGreetingService());
+        controller = new ConstructorInjectedController(new ConstructorInjectedGreetingService());
     }
 
     @Test

--- a/src/test/java/guru/springframework/sfgdi/controllers/PropertyInjectedControllerTest.java
+++ b/src/test/java/guru/springframework/sfgdi/controllers/PropertyInjectedControllerTest.java
@@ -1,6 +1,6 @@
 package guru.springframework.sfgdi.controllers;
 
-import guru.springframework.sfgdi.services.ConstructorGreetingService;
+import guru.springframework.sfgdi.services.PropertyInjectedGreetingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,7 @@ class PropertyInjectedControllerTest {
     void setUp() {
         controller = new PropertyInjectedController();
 
-        controller.greetingService = new ConstructorGreetingService();
+        controller.greetingService = new PropertyInjectedGreetingService();
     }
 
     @Test

--- a/src/test/java/guru/springframework/sfgdi/controllers/SetterInjectedControllerTest.java
+++ b/src/test/java/guru/springframework/sfgdi/controllers/SetterInjectedControllerTest.java
@@ -1,6 +1,6 @@
 package guru.springframework.sfgdi.controllers;
 
-import guru.springframework.sfgdi.services.ConstructorGreetingService;
+import guru.springframework.sfgdi.services.SetterInjectedGreetingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +11,7 @@ class SetterInjectedControllerTest {
     @BeforeEach
     void setUp() {
         controller = new SetterInjectedController();
-        controller.setGreetingService(new ConstructorGreetingService());
+        controller.setGreetingService(new SetterInjectedGreetingService());
     }
 
     @Test


### PR DESCRIPTION
ConstructorGreetingService was used in all Controller Tests, regardless of the DI.
Changed ConstructorGreetingService to ConstructorInjectedGreetingService, due to naming consistency.